### PR TITLE
rc/prompt.ksh: fixes/improvements for PS1.set and _relative_pwd.get

### DIFF
--- a/.ksh/rc/prompt.ksh
+++ b/.ksh/rc/prompt.ksh
@@ -14,13 +14,13 @@ function PS1.set
     while [[ $remaining ]]
     do
         prefix=${remaining%%'\'*}
-        remaining=${remaining#$prefix}
-        var+="$prefix"
+        remaining=${remaining#"$prefix"}
+        var+=$prefix
 
         case ${remaining:1:1} in
             A)    var+="\$(printf '%(%R)T')";;
             b)    var+="\${_git_status}";;
-            @)    [[ ${.sh.lversion[3]:0:4} < "2020" ]] \
+            @)    ((.sh.version < 20200101)) \
                   && var+="\$(printf '%(%I:%M %p)T')" \
                   || var+="\$(printf '%(%l:%M %p)T')";;  # true == before 2020, false == after 2020
             d)    var+="\$(printf '%(%a %b:%d)T')";;
@@ -28,19 +28,19 @@ function PS1.set
             h)    [[ -z ${HOSTNAME} ]] && var+=$(hostname -s) || var+="${HOSTNAME}";;
             H)    var+=$(hostname);;
             j)    var+="\$(jobs | wc -l)";;
-            l)    [[ -z ${TTY} ]] && var+="\$(basename \"\$(tty)\")" || var+="${TTY}";;
+            l)    [[ -z ${TTY} ]] && var+=$(basename "$(tty)") || var+="${TTY}";;
             n)    var+=$'\n';;
             p)    var+="\${_relative_pwd}" ;; # added this one to the list
             r)    var+=$'\r';;
-            s)    var+="\$(basename \"\$0\")";;
+            s)    var+=$(basename "$0") ;;
             S)    var+="\${SHLVL}" ;; # added this one to the list
             t)    var+="\$(printf '%(%H:%M:%S)T')";;
             T)    var+="\$(printf '%(%I:%M:%S)T')";;
             u)    var+=$USER;;
-            v)    var+="\${.sh.lversion[2]}";;
-            V)    var+="\${.sh.lversion[2]} (\${.sh.lversion[1]})";;
-            w)    var+="\$(pwd)";;
-            W)    var+="\$(basename \"\$(pwd)\")";;
+            v)    var+=${.sh.lversion[2]} ;;
+            V)    var+="${.sh.lversion[2]} (${.sh.lversion[1]})";;
+            w)    var+="\$PWD";;
+            W)    var+="\$(basename \"\$PWD\")";;
           '#')    var+=!;;
             !)    var+=!;;
           '$')    if (( $(id -u) == 0 ))
@@ -52,11 +52,11 @@ function PS1.set
           '\')    var+='\\';;
       '['|']')    ;;
         [0-7])    case ${remaining:1:3} in
-                   [0-7][0-7][0-7])   k=4;;
-                            [0-7][0-7])   k=3;;
-                                     *)   k=2;;
+                   [0-7][0-7][0-7] )  k=4;;
+                        [0-7][0-7]*)  k=3;;
+                                  *)  k=2;;
                   esac
-                  eval n="\$'"${remaining:0:k}"'"
+                  eval "n=\$'${remaining:0:k}'"
                   var+=$n
                   remaining=${remaining:k}
                   continue ;;
@@ -74,90 +74,17 @@ function _git_status.get
     .sh.value=$(git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/[\1]/')
 }
 
-# _relative_pwd.get is actually from polyglot.sh
-# https://github.com/agkozak/polyglot
-# Copyright 2017-2020 Alexandros Kozak
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
-function _relative_pwd.get {
-
-    typeset PG_DIRTRIM_ELEMENTS= PG_PWD_MINUS_HOME= PG_ABBREVIATED_PATH=
-    typeset IFS
-
-      PG_DIRTRIM_ELEMENTS="${1:-2}"
-
-      # If root has / as $HOME, print /, not ~
-      [ "$PWD" = '/' ] && .sh.value="$" && return
-      [ "$PWD" = "$HOME" ] && .sh.value="~" && return
-
-      case $HOME in
-        /) PG_PWD_MINUS_HOME="$PWD" ;;            # In case root's $HOME is /
-        *) PG_PWD_MINUS_HOME="${PWD#$HOME}" ;;
-      esac
-
-      if [ "$PG_DIRTRIM_ELEMENTS" -eq 0 ]; then
-        [ "$HOME" = '/' ] && .sh.value="$(printf '%s' "$PWD")" && return
-        case $PWD in
-          ${HOME}*) .sh.value="$(printf '~%s' "$PG_PWD_MINUS_HOME")" ;;
-          *) .sh.value="$(printf '%s' "$PWD")" ;;
-        esac
-      else
-        # Calculate the part of $PWD that will be displayed in the prompt
-        IFS='/'
-        # shellcheck disable=SC2086
-        set -- $PG_PWD_MINUS_HOME
-        shift                                  # Discard empty first field preceding /
-
-        # Discard path elements > $PG_PROMPT_DIRTRIM
-        while [ $# -gt "$PG_DIRTRIM_ELEMENTS" ]; do
-          shift
-        done
-
-        # Reassemble the remaining path elements with slashes
-        while [ $# -ne 0 ]; do
-          PG_ABBREVIATED_PATH="${PG_ABBREVIATED_PATH}/$1"
-          shift
-        done
-
-        # If the working directory has not been abbreviated, display it thus
-        if [ "$PG_ABBREVIATED_PATH" = "${PG_PWD_MINUS_HOME}" ]; then
-          if [ "$HOME" = '/' ]; then
-            .sh.value="$(printf '%s' "$PWD")"
-          else
-            case $PWD in
-              ${HOME}*) .sh.value=$(printf '~%s' "${PG_PWD_MINUS_HOME}") ;;
-              *) .sh.value="$(printf '%s' "$PWD")" ;;
-            esac
-          fi
-        # Otherwise include an ellipsis to show that abbreviation has taken place
-        else
-          if [ "$HOME" = '/' ]; then
-            .sh.value="$(printf '...%s' "$PG_ABBREVIATED_PATH")"
-          else
-            case $PWD in
-              ${HOME}*) .sh.value="$(printf '~/...%s' "$PG_ABBREVIATED_PATH")" ;;
-              *) .sh.value="$(printf '...%s' "$PG_ABBREVIATED_PATH")" ;;
-            esac
-          fi
-        fi
-      fi
+# Discipline function for relative present working directory
+# by Martijn Dekker <martijn@inlv.org> 2020-08-09; public domain
+function _relative_pwd.get
+{
+    typeset del ellip=$'\u2026' v=$PWD keep=*/*   # add /* for each element to keep
+    ((${#ellip}==1)) || ellip='...'
+    [[ ($v == "$HOME" || $v == "$HOME"/*) && $HOME != / ]] && v=\~${v#"$HOME"}
+    del=${v%/$keep}/
+    [[ $v == /*/$keep ]] && v=$ellip/${v#"$del"}
+    [[ $v == \~/*/$keep ]] && v=\~/$ellip/${v#"$del"}
+    .sh.value=$v
 }
 
 # set prompt


### PR DESCRIPTION
function PS1.set:
- Fix quoting bugs. Especially `remaining=${remaining#$prefix}` was
  buggy as the `$prefix` pattern wan't quoted, so special characters
  in `$prefix` could corrupt the value.
- `\@`: Use arithmetic expansion for `.sh.version` date check.
  (ksh special-cases .sh.version in arithmetic and takes only the
  date, converting it to a number.)
- `\l`, `\s`, `\w`, `\W`: Optimise performance by removing some unnecessary
  command substitutions and inserting static values directly.
- Fix bug in 2-digit octal escapes by adding missing `*`.

function _relative_pwd.get:
- Replace by new version that provides the same functionality
  faster and in about 15% of the size.
- Add a UTF-8 ellipsis that is only used if a UTF-8 locale is
  active (i.e. if `${#ellip}` measures 1 character).